### PR TITLE
Pass an absolute path to build.ImportDir(). It is assumed to always be t...

### DIFF
--- a/match.go
+++ b/match.go
@@ -106,13 +106,16 @@ func matchPackages(pattern string) []string {
 			if !match(name) {
 				return nil
 			}
-			_, err = buildContext.ImportDir(path, 0)
+			if path, err = filepath.Abs(path); err != nil {
+				return nil
+			}
+			pkg, err := buildContext.ImportDir(path, 0)
 			if err != nil {
 				if _, noGo := err.(*build.NoGoError); noGo {
 					return nil
 				}
 			}
-			pkgs = append(pkgs, name)
+			pkgs = append(pkgs, pkg.ImportPath)
 			return nil
 		})
 	}
@@ -239,10 +242,14 @@ func matchPackagesInFS(pattern string) []string {
 		if !match(name) {
 			return nil
 		}
-		if _, err = build.ImportDir(path, 0); err != nil {
+		if path, err = filepath.Abs(path); err != nil {
 			return nil
 		}
-		pkgs = append(pkgs, name)
+		pkg, err := build.ImportDir(path, 0)
+		if err != nil {
+			return nil
+		}
+		pkgs = append(pkgs, pkg.ImportPath)
 		return nil
 	})
 	return pkgs


### PR DESCRIPTION
...he case.

Explanation at https://code.google.com/p/go/issues/detail?id=9057

This fixes using "errcheck ./..."

Also, add the ImportPath instead of whatever name provided; normally "." or things like "./lib".

This doesn't fix "errcheck ." locally.