### PR TITLE
Use correct goroot source path for Go 1.4.

### DIFF
--- a/go13.go
+++ b/go13.go
@@ -2,6 +2,9 @@
 
 package gotool
 
-import "path/filepath"
+import (
+	"path/filepath"
+	"runtime"
+)
 
-var gorootSrcPkg = filepath.Join(goroot, "src/pkg")
+var gorootSrcPkg = filepath.Join(runtime.GOROOT(), "src", "pkg")

--- a/go13.go
+++ b/go13.go
@@ -1,0 +1,7 @@
+// +build !go1.4
+
+package gotool
+
+import "path/filepath"
+
+var gorootSrcPkg = filepath.Join(goroot, "src/pkg")

--- a/go14.go
+++ b/go14.go
@@ -2,6 +2,9 @@
 
 package gotool
 
-import "path/filepath"
+import (
+	"path/filepath"
+	"runtime"
+)
 
-var gorootSrcPkg = filepath.Join(goroot, "src")
+var gorootSrcPkg = filepath.Join(runtime.GOROOT(), "src")

--- a/go14.go
+++ b/go14.go
@@ -1,0 +1,7 @@
+// +build go1.4
+
+package gotool
+
+import "path/filepath"
+
+var gorootSrcPkg = filepath.Join(goroot, "src")

--- a/match.go
+++ b/match.go
@@ -41,10 +41,7 @@ import (
 	"strings"
 )
 
-var (
-	goroot       = filepath.Clean(runtime.GOROOT())
-	gorootSrcPkg = filepath.Join(goroot, "src/pkg")
-)
+var goroot = filepath.Clean(runtime.GOROOT())
 
 var buildContext = build.Default
 

--- a/match.go
+++ b/match.go
@@ -37,11 +37,8 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 )
-
-var goroot = filepath.Clean(runtime.GOROOT())
 
 var buildContext = build.Default
 


### PR DESCRIPTION
- In Go 1.4, the goroot source path has moved from `$GOROOT/src/pkg` to
`$GOROOT/src`. This updates the variable and allows "std" pattern to work
correctly again.
- Fixes #3.
- Fixes dominikh/implements#11.