### PR TITLE
Improve docs.

### DIFF
--- a/match.go
+++ b/match.go
@@ -152,7 +152,12 @@ func (c Context) importPathsNoDotExpansion(args []string) []string {
 	return out
 }
 
-// importPaths returns the import paths to use for the given command line.
+// ImportPaths returns the import paths to use for the given arguments.
+//
+// The path "all" is expanded to all packages in $GOPATH and $GOROOT.
+// The path "std" is expanded to all packages in the Go standard library.
+// The string "..." is treated as a wildcard within a path.
+// Relative import paths are not converted to full import paths.
 func (c Context) ImportPaths(args []string) []string {
 	args = c.importPathsNoDotExpansion(args)
 	var out []string

--- a/tool.go
+++ b/tool.go
@@ -4,10 +4,12 @@ package gotool
 
 // export functions as here to make it easier to keep the implementations up to date with upstream.
 
-// ImportPaths returns the import paths to use for the given arguments.
+// ImportPaths returns the import paths to use for the given arguments using default context.
+//
 // The path "all" is expanded to all packages in $GOPATH and $GOROOT.
 // The path "std" is expanded to all packages in the Go standard library.
 // The string "..." is treated as a wildcard within a path.
+// Relative import paths are not converted to full import paths.
 func ImportPaths(args []string) []string {
 	return DefaultContext.ImportPaths(args)
 }


### PR DESCRIPTION
Mention that relative import paths are returned as relative import paths, they are not converted to full import paths.

They are cleaned, however. For example, `"./foo//bar"` becomes `"./foo/bar"`.

Fixes #5.