### PR TITLE
Document that wildcard matching excludes some directories

### DIFF
--- a/tool.go
+++ b/tool.go
@@ -24,6 +24,8 @@ type Context struct {
 // The path "std" is expanded to all packages in the Go standard library.
 // The path "cmd" is expanded to all Go standard commands.
 // The string "..." is treated as a wildcard within a path.
+// When matching recursively, directories are ignored if they are prefixed with
+// a dot or an underscore (such as ".foo" or "_foo"), or are named "testdata".
 // Relative import paths are not converted to full import paths.
 // If args is empty, a single element "." is returned.
 func (c *Context) ImportPaths(args []string) []string {
@@ -37,6 +39,8 @@ func (c *Context) ImportPaths(args []string) []string {
 // The path "std" is expanded to all packages in the Go standard library.
 // The path "cmd" is expanded to all Go standard commands.
 // The string "..." is treated as a wildcard within a path.
+// When matching recursively, directories are ignored if they are prefixed with
+// a dot or an underscore (such as ".foo" or "_foo"), or are named "testdata".
 // Relative import paths are not converted to full import paths.
 // If args is empty, a single element "." is returned.
 func ImportPaths(args []string) []string {


### PR DESCRIPTION
I noticed one of my directories was being excluded when I didn't expect it to. The tool excludes testdata, as well as directories beginning with dot or underscore when recursively matching.

This is expected behaviour, but it wasn't documented publicly, this change adds those docs according to the behaviour in https://github.com/kisielk/gotool/blob/master/match.go#L91-L95.

I'm not convinced on the wording, so happy for this to be closed for another approach.

Thanks for the tool.